### PR TITLE
Include cvs-hashmap.h to fix compile error in parodus

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 2.8.7)
 
 set(PROJ_REBAR rebar-c)
 
-file(GLOB HEADERS rebar-c.h)
+file(GLOB HEADERS rebar-c.h cvs-hashmap.h)
 set(SOURCES linked_list.c cvs-hashmap.c)
 
 add_library(${PROJ_REBAR} STATIC ${HEADERS} ${SOURCES})
@@ -25,4 +25,4 @@ set_target_properties(${PROJ_REBAR}.shared PROPERTIES OUTPUT_NAME ${PROJ_REBAR})
 
 install (TARGETS ${PROJ_REBAR} DESTINATION lib${LIB_SUFFIX})
 install (TARGETS ${PROJ_REBAR}.shared DESTINATION lib${LIB_SUFFIX})
-install (FILES rebar-c.h DESTINATION include/${PROJ_REBAR})
+install (FILES rebar-c.h cvs-hashmap.h DESTINATION include/${PROJ_REBAR})


### PR DESCRIPTION
Gives compile error while building in parodus.

build/_install/include/rebar-c/rebar-c.h:350:25: fatal error: cvs-hashmap.h: No such file or directory
 #include "cvs-hashmap.h"
                         ^
compilation terminated.
make[2]: *** [src/CMakeFiles/parodus.dir/networking.c.o] Error 1
make[1]: *** [src/CMakeFiles/parodus.dir/all] Error 2
make: *** [all] Error 2
